### PR TITLE
Mark DIServiceHost public to allow existing service provider

### DIFF
--- a/src/AxaFrance.Extensions.DependencyInjection.WCF/DIServiceHost.cs
+++ b/src/AxaFrance.Extensions.DependencyInjection.WCF/DIServiceHost.cs
@@ -6,7 +6,7 @@
     using System.ServiceModel.Description;
     using Microsoft.Extensions.DependencyInjection;
 
-    internal class DIServiceHost : ServiceHost
+    public class DIServiceHost : ServiceHost
     {
         public DIServiceHost(IServiceProvider serviceProvider, Type serviceType, Uri[] baseAddresses)
             : base(serviceType, baseAddresses)


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [x] I have run `<TEST COMMAND>` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Marking DIServiceHost as public open a possibility to use an existing service provider. In my use case, i would like to reuse most of the services that are configured in my asp.net core project.

Context: 
I run into a project that are using WCF as their way of communication. This WCF service is alongside asp.net core 2.2 and running as a hosted service. I want to use most of the services configured in asp.net core side. 